### PR TITLE
fix pyproject syntax

### DIFF
--- a/scripts/pybayesx/pyproject.toml
+++ b/scripts/pybayesx/pyproject.toml
@@ -7,8 +7,8 @@ dependencies = [
     "astropy ~= 5.2",
     "getdist ~= 1.4"
 ]
-license = "MIT"
-authors = "Ryan Cox ryan.cox@vuw.ac.nz"
+license = {file = "LICENSE"}
+authors = [{name = "Ryan Cox", email = "ryan.cox@vuw.ac.nz"}]
 
 [project.scripts]
 pbx = "pybayesx:scripts.main"


### PR DESCRIPTION
Accidentally pushed to branch after merge. Just tiding up again.